### PR TITLE
build: add separate target to setup binaries

### DIFF
--- a/scripts/dev_scripts/copyright-checker.sh
+++ b/scripts/dev_scripts/copyright-checker.sh
@@ -22,7 +22,7 @@ for f in $files; do
         startyear=$currentyear
     fi
     if ! grep -i -e "Copyright (c) $startyear - $currentyear, Oracle and/or its affiliates. All rights reserved." "$f" 1>/dev/null;then
-        if [[ $f =~ .*\.(js$|py$|java$|tf$|go$|sh$|dl$|yaml$) ]] || [[ "${f##*/}" = "Dockerfile" ]];then
+        if [[ $f =~ .*\.(js$|py$|java$|tf$|go$|sh$|dl$|yaml$) ]] || [[ "${f##*/}" = "Dockerfile" ]] || [[ "${f##*/}" = "Makefile" ]];then
           missing_copyright_files+=("$f")
         fi
     fi
@@ -46,7 +46,7 @@ if [ ${#missing_copyright_files[@]} -ne 0 ]; then
             if [ ${#missing_license_note} -eq 0 ]; then
                 expected="$expected\n\/\* $license_note \*\/"
             fi
-        elif [[ $f =~ .*\.(py$|tf$|sh$|yaml$) ]] || [[ "${f##*/}" = "Dockerfile" ]]; then
+        elif [[ $f =~ .*\.(py$|tf$|sh$|yaml$) ]] || [[ "${f##*/}" = "Dockerfile" ]] || [[ "${f##*/}" = "Makefile" ]]; then
             expected="# Copyright \(c\) $startyear - $currentyear, Oracle and\/or its affiliates\. All rights reserved\."
             if [ ${#missing_license_note} -eq 0 ]; then
                 expected="$expected\n# $license_note"


### PR DESCRIPTION
To make it easier to download and install binaries that are not tracked by package managers, this PR adds a separate target to the `Makefile` (`setup-binaries`), which can be directly used for example in a `Dockerfile`.

Note that if the corresponding files exist, we won't try to download and install. In that case, to force download and install we can use `make clean setup-binaries` or `make nuke setup-binaries`.

This would help managing `slsa-verifier` until we have a better solution: see #16.

Signed-off-by: behnazh-w <behnaz.hassanshahi@oracle.com>