### PR TITLE
chore(deps): update cyclonedx-bom and remove deprecated CLI command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ upgrade-go:
 # Generate a Software Bill of Materials (SBOM).
 .PHONY: sbom
 sbom: requirements
-	cyclonedx-bom --force --requirements --format json --output dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-sbom.json
+	cyclonedx-py --force --requirements --format json --output dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-sbom.json
 	$$HOME/go/bin/cyclonedx-gomod mod -json -output dist/$(PACKAGE_NAME)-$(PACKAGE_VERSION)-sbom-go.json $(REPO_PATH)
 
 # Generate a requirements.txt file containing version and integrity hashes for all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
     # See https://github.com/pypa/pip-audit/commit/22d7e4c7f5acd20852c57b52b46e861a716ab09f.
     "pip-audit >=2.4.8,<3.0.0,!=2.4.9",
     "pylint >=2.9.3,<2.16.2",
-    "cyclonedx-bom >=3.5.0,<4.0.0",
+    "cyclonedx-bom >=3.11.0,<4.0.0",
 ]
 docs = [
     "sphinx >=5.3.0,<7.0.0",


### PR DESCRIPTION
This PR updates `cyclonedx-bom` Python module and uses `cyclonedx-py` instead of the deprecated `cyclonedx-bom` CLI command.

For more information see: https://github.com/CycloneDX/cyclonedx-python/releases/tag/v3.11.0.