### PR TITLE
fix: do not log check_module object to avoid info leakage

### DIFF
--- a/src/macaron/slsa_analyzer/registry.py
+++ b/src/macaron/slsa_analyzer/registry.py
@@ -201,7 +201,7 @@ class Registry:
         else:
             logger.critical(
                 "Cannot resolve the source file of %s even when it has been resolved.",
-                str(check_module),
+                check.check_id,
             )
             return False
 


### PR DESCRIPTION
CodeQL has found [an info leakage bug](https://github.com/oracle-samples/macaron/security/code-scanning/1) in Macaron, which should be fixed in this PR :nerd_face: 