### PR TITLE
ci: enable CodeQL for all files

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -14,10 +14,6 @@ on:
     branches:
     - main
     - staging
-    # Avoid unnecessary scans of pull requests.
-    paths:
-    - '**/*.py'
-    - '**/*.go'
   schedule:
   - cron: 20 15 * * 3
 permissions:


### PR DESCRIPTION
[Scorecards](https://github.com/ossf/scorecard) lowers the score if a commit is not analyzed by CodeQL. We had initially added filters to avoid running CodeQL unnecessarily, e.g., on `*.md` files, but to follow Scorecards recommendations this PR removes the filtering.