### PR TITLE
chore: update Souffle to version 2.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,10 @@ souffle:
 		echo "Installing system dependency: souffle" && \
 	    case $(LINUX_DISTRO) in \
 	        "Oracle Linux") \
-                sudo dnf -y install https://github.com/souffle-lang/souffle/releases/download/2.3/x86_64-oraclelinux-8-souffle-2.3-Linux.rpm \
+                sudo dnf -y install https://github.com/souffle-lang/souffle/releases/download/2.4/x86_64-oraclelinux-8-souffle-2.4-Linux.rpm \
                 ;; \
 	        "Fedora Linux") \
-                sudo dnf -y install https://github.com/souffle-lang/souffle/releases/download/2.3/x86_64-fedora-34-souffle-2.3-Linux.rpm \
+                sudo dnf -y install https://github.com/souffle-lang/souffle/releases/download/2.4/x86_64-fedora-34-souffle-2.4-Linux.rpm \
                 ;; \
             "Ubuntu") \
                 sudo wget https://souffle-lang.github.io/ppa/souffle-key.public -O /usr/share/keyrings/souffle-archive-keyring.gpg; \

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -200,7 +200,7 @@ enabled=1\
         make \
         pkg-config \
         rpm-build \
-    && git clone --depth=1 https://github.com/souffle-lang/souffle/ -b 2.3 \
+    && git clone --depth=1 https://github.com/souffle-lang/souffle/ -b 2.4 \
     && cd souffle \
     && cmake -S . -B build -DSOUFFLE_DOMAIN_64BIT=ON -DCMAKE_INSTALL_PREFIX="/usr/local" \
     && nproc="$(nproc)" \

--- a/docker/Dockerfile.final
+++ b/docker/Dockerfile.final
@@ -10,7 +10,7 @@
 # Note that the local machine must login to ghcr.io so that Docker could pull the ghcr.io/oracle-samples/macaron-base
 # image for this build.
 
-FROM ghcr.io/oracle-samples/macaron-base:latest@sha256:b4b63d3be26fc00be06389b48d0bf49450cac402d64692d354f7ebdd40bb8828
+FROM ghcr.io/oracle-samples/macaron-base:latest@sha256:5f2ed797b2b1e7e80d151fabc85e220a6bd57a9808c73aaa3cf466a038061a1d
 
 ENV HOME="/home/macaron"
 


### PR DESCRIPTION
Closes #203 .

TODO:
- [x] Update Souffle version in the base Docker image
  - [x] Run the workflow to build the updated base Docker image - https://github.com/oracle-samples/macaron/actions/runs/4933098613
- [x] Update Souffle version in Makefile
- [x] Update the hash of the base Docker image in `Dockerfile.final`