### PR TITLE
fix: upgrade requests to 2.31.0 to fix CVE-2023-32681

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version", "description"]
 license = {file = "LICENSE.txt"}
 readme = "README.md"
 dependencies = [
-    "requests >=2.28.0,<3.0.0",
+    "requests >=2.31.0,<3.0.0",
     "pydriller >=2.0,<3.0.0",
     "yamale >=4.0.3,<5.0.0",
     "packaging >=21.3,<24.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,7 @@ dev = [
     "mypy >=0.921,<1.4",
     "types-pyyaml >=6.0.4,<7.0.0",
     "types-requests >=2.25.6,<3.0.0",
-    # Exclude pip-audit v2.4.9 because it has a bug.
-    # See https://github.com/pypa/pip-audit/commit/22d7e4c7f5acd20852c57b52b46e861a716ab09f.
-    "pip-audit >=2.4.8,<3.0.0,!=2.4.9",
+    "pip-audit >=2.5.6,<3.0.0",
     "pylint >=2.9.3,<2.17.5",
     "cyclonedx-bom >=3.11.0,<4.0.0",
 ]


### PR DESCRIPTION
This PR upgrades `requests` dependency to `2.31.0` to fix `CVE-2023-32681`.
See https://github.com/psf/requests/releases/tag/v2.31.0.