### PR TITLE
fix: do not overwrite an existing check relationship when a check has no parent in the Registry

### DIFF
--- a/src/macaron/slsa_analyzer/registry.py
+++ b/src/macaron/slsa_analyzer/registry.py
@@ -69,10 +69,11 @@ class Registry:
             logger.error("The check registered is invalid.")
             sys.exit(1)
 
-        # Update the check relationship mapping. If this check does not depend on any check,
-        # we add it as a standalone check ONLY when _check_relationships_mapping does not have an entry for it.
+        # Update the check relationship mapping. Even though a check might not depend on any other checks, other
+        # checks can still depend on it, and therefore it might have been initialized and added to the mapping
+        # already. So we need to check if it already exists in `_check_relationships_mapping`.
         if not check.depends_on:
-            if self._check_relationships_mapping.get(check.check_id, None) is None:
+            if check.check_id not in self._check_relationships_mapping:
                 self._check_relationships_mapping[check.check_id] = {}
         else:
             for parent_relationship in check.depends_on:

--- a/src/macaron/slsa_analyzer/registry.py
+++ b/src/macaron/slsa_analyzer/registry.py
@@ -69,11 +69,11 @@ class Registry:
             logger.error("The check registered is invalid.")
             sys.exit(1)
 
-        # Update the check relationship mapping.
-        # If this check does not depend on any check,
-        # we add it as a standalone check.
+        # Update the check relationship mapping. If this check does not depend on any check,
+        # we add it as a standalone check ONLY when _check_relationships_mapping does not have an entry for it.
         if not check.depends_on:
-            self._check_relationships_mapping[check.check_id] = {}
+            if self._check_relationships_mapping.get(check.check_id, None) is None:
+                self._check_relationships_mapping[check.check_id] = {}
         else:
             for parent_relationship in check.depends_on:
                 if not self._add_relationship_entry(check.check_id, parent_relationship):


### PR DESCRIPTION
Closes #237 