### PR TITLE
build: use make setup install commitizen

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
     - name: Create empty virtual environment for Actions
       run: mkdir .venv
     - name: Install dependencies
-      run: make setup
+      run: make setup-github-actions
 
     - name: Set up user
       run: |
@@ -184,7 +184,7 @@ jobs:
     - name: Create empty virtual environment for Actions
       run: mkdir .venv
     - name: Install dependencies
-      run: make setup
+      run: make setup-github-actions
 
     # Create the Release Notes using commitizen.
     - name: Create Release Notes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,10 +50,11 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Set up Commitizen
-      run: |
-        pip install --upgrade pip wheel
-        pip install 'commitizen ==2.37.1'
+    # Prepare the environment to run commitizen.
+    - name: Create empty virtual environment for Actions
+      run: mkdir .venv
+    - name: Install dependencies
+      run: make setup
 
     - name: Set up user
       run: |
@@ -174,17 +175,18 @@ jobs:
         rm -f "$ASSET_NAME"
         rm -f "$CHECKSUMS"
 
-    # Create the Release Notes using commitizen.
     - name: Set up Python
       uses: actions/setup-python@57ded4d7d5e986d7296eab16560982c6dd7c923b # v4.6.0
       with:
         python-version: '3.11'
 
-    - name: Set up Commitizen
-      run: |
-        pip install --upgrade pip wheel
-        pip install 'commitizen ==2.37.1'
+    # Prepare the environment to run commitizen.
+    - name: Create empty virtual environment for Actions
+      run: mkdir .venv
+    - name: Install dependencies
+      run: make setup
 
+    # Create the Release Notes using commitizen.
     - name: Create Release Notes
       run: cz changelog --dry-run "$(cz version --project)" > RELEASE_NOTES.md
 

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,15 @@ upgrade-go:
 	go get $$(go list -f '{{if not (or .Main .Indirect)}}{{.Path}}{{end}}' -m all)
 	go mod tidy
 
+# Install dependencies for GitHub Actions, such as commitizen that we need as part of
+# the automatic release in the release GitHub Actions and with this target we can skip
+# setting up unrelated packages.
+.PHONY: setup-github-actions
+setup-github-actions:
+	python -m pip install --upgrade pip
+	python -m pip install --upgrade wheel
+	python -m pip install --upgrade --upgrade-strategy eager --editable .[actions]
+
 # Generate a Software Bill of Materials (SBOM).
 .PHONY: sbom
 sbom: requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ version_files = [
     "src/macaron/__init__.py:__version__",
 ]
 major_version_zero = false
-version = "2.6.0"
+version = "0.0.0"
 
 
 # https://github.com/pytest-dev/pytest-cov


### PR DESCRIPTION
Originally `commitizen` was installed individually for performance reasons. However, this meant that we had to always manually update `commitizen` in the GitHub Action. This PR runs `make setup` to install `commitizen`, which means installing all the packages but on the plus side we won't have to worry about updating it manually anymore.