### PR TITLE
ci(deploy): add a workflow to deploy docs to GitHub pages

### DIFF
--- a/.github/workflows/_deploy-github-pages.yaml
+++ b/.github/workflows/_deploy-github-pages.yaml
@@ -19,11 +19,6 @@ permissions:
   contents: read
   pages: write
   id-token: write
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: pages
-  cancel-in-progress: false
 
 jobs:
   # Download the generated docs archive, verify its hash, and deploy to GitHub pages.

--- a/.github/workflows/_deploy-github-pages.yaml
+++ b/.github/workflows/_deploy-github-pages.yaml
@@ -70,11 +70,13 @@ jobs:
 
     - name: Setup Pages
       uses: actions/configure-pages@f156874f8191504dae5b037505266ed5dda6c382 # v3.0.6
-    - name: Upload artifact
+
+    - name: Upload documentation artifact
       uses: actions/upload-pages-artifact@64bcae551a7b18bcb9a09042ddf1960979799187 # v1.0.8
       with:
         # Upload html/ directory.
         path: html
+
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@af48cf94a42f2c634308b1c9dc0151830b6f190a # v2.0.1

--- a/.github/workflows/_deploy-github-pages.yaml
+++ b/.github/workflows/_deploy-github-pages.yaml
@@ -1,0 +1,80 @@
+# Copyright (c) 2023 - 2023, Oracle and/or its affiliates. All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/.
+
+# This workflow deploys the documentations to GitHub Pages.
+name: Deploy static content to Pages
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        type: string
+        required: true
+        description: The artifact name that contains docs content
+      artifact-sha256:
+        type: string
+        required: true
+        description: The sha of the artifact that contains docs content
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  # Download the generated docs archive, verify its hash, and deploy to GitHub pages.
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out repository
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      with:
+        fetch-depth: 0
+
+    - name: Download artifact
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: dist
+
+    # Verify hashes by first computing hashes for the artifacts and then comparing them
+    # against the hashes for the artifact.
+    - name: Verify the artifact hash
+      env:
+        ARTIFACT_HASH: ${{ inputs.artifact-sha256 }}
+      run: |
+        set -euo pipefail
+        echo "Hash of package should be $ARTIFACT_HASH."
+        echo "$ARTIFACT_HASH" | base64 --decode | sha256sum --strict --check --status || exit 1
+
+    # Prepare the docs content.
+    - name: Prepare docs for release
+      env:
+        DIST_PATH: dist
+      run: |
+        DOCS_PATH=$(find "$DIST_PATH" -depth -type f -name 'macaron-*-docs-html.zip' | head -n 1)
+        if [[ -z "${DOCS_PATH}" ]];
+        then
+            echo "Unable to find Macaron docs files in ${DIST_PATH}."
+            exit 1
+        fi
+        unzip "$DOCS_PATH"
+
+    - name: Setup Pages
+      uses: actions/configure-pages@f156874f8191504dae5b037505266ed5dda6c382 # v3.0.6
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@64bcae551a7b18bcb9a09042ddf1960979799187 # v1.0.8
+      with:
+        # Upload html/ directory.
+        path: html
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@af48cf94a42f2c634308b1c9dc0151830b6f190a # v2.0.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -293,8 +293,8 @@ jobs:
       pages: write
       id-token: write
     with:
-      # TODO: use ${{ env.ARTIFACT_OS }} and ${{ env.ARTIFACT_PYTHON }}
-      # when this issue is addressed: https://github.com/actions/runner/issues/2394.
+      # TODO: use ${{ env.ARTIFACT_NAME }} when this issue is addressed:
+      # https://github.com/actions/runner/issues/2394.
       artifact-name: artifact-ubuntu-latest-python-3.11
       artifact-sha256: ${{ needs.build.outputs.artifacts-sha256 }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -283,6 +283,21 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.REPO_ACCESS_TOKEN }}
 
+  # Publish docs to GitHub pages.
+  github-pages:
+    needs: [build, release]
+    name: Deploy GitHub pages
+    uses: ./.github/workflows/_deploy-github-pages.yaml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    with:
+      # TODO: use ${{ env.ARTIFACT_OS }} and ${{ env.ARTIFACT_PYTHON }}
+      # when this issue is addressed: https://github.com/actions/runner/issues/2394.
+      artifact-name: artifact-ubuntu-latest-python-3.11
+      artifact-sha256: ${{ needs.build.outputs.artifacts-sha256 }}
+
   # Send out release notifications after the Release was published on GitHub.
   # Uncomment the `if` to disable sending release notifications.
   notifications:


### PR DESCRIPTION
Closes #248 

By running this reusable workflow, the documentations will be published at https://oracle-samples.github.io/macaron/.