### PR TITLE
feat: add problog rule inference to build as code check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "jinja2 >=3.1.2,<4.0.0",
     "SQLAlchemy >=2.0.0,<3.0.0",
     "defusedxml >=0.7.1,<1.0.0",
+    "problog >=2.2.4,<3.0.0"
 ]
 keywords = []
 # https://pypi.org/classifiers/


### PR DESCRIPTION
## Priority (v1)
- [ ] Refactor build as code `run_check` method into smaller subchecks.
- [ ] Use ProbLog predicates to receive subcheck values from within prolog string.
- [ ] Write ProbLog rules to evaluate the check's overall confidence score.
- [ ] Update BuildAsCodeTable to receive the information.
- [ ] Use overall confidence score to make a decision about check passing.
- [ ] Update check_result to store confidence score.

## Later
- [ ] Update tests. 
- [ ] Refine refactoring - can things be done more efficiently/effectively?