### PR TITLE
chore(deps): fix actions/checkout versions in comments

### DIFF
--- a/.github/workflows/_build_docker.yaml
+++ b/.github/workflows/_build_docker.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
 
     - name: Check out repository
-      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.1.0
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       with:
         fetch-depth: 0
 

--- a/.github/workflows/build_base_image.yaml
+++ b/.github/workflows/build_base_image.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
 
     - name: Check out repository
-      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.1.0
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
Because these GitHub Actions did not have the latest version tags, Dependabot had failed to correctly update the version tags in comments.