### PR TITLE
chore: remove running the policy engine when --show-prelude is provided

### DIFF
--- a/src/macaron/policy_engine/policy_engine.py
+++ b/src/macaron/policy_engine/policy_engine.py
@@ -139,15 +139,25 @@ def _check_version(database_path: str) -> None:
             sys.exit(os.EX_DATAERR)
 
 
-def run_policy_engine(database_path: str, show_prelude: bool, policy_file: str) -> dict:
+def show_prelude(database_path: str) -> None:
+    """Show the Datalog prelude for a database and exit.
+
+    Parameters
+    ----------
+    database_path: str
+        The SQLite database file to show the prelude for.
+    """
+    prelude = get_generated(database_path)
+    logger.info("\n%s", prelude)
+
+
+def run_policy_engine(database_path: str, policy_file: str) -> dict:
     """Evaluate a policy based on configuration and exit.
 
     Parameters
     ----------
     database_path: str
         The SQLite database file to evaluate the policy against
-    show_prelude: bool
-        Just show the policy prelude and exit.
     policy_file: str
         The policy file to evaluate
 
@@ -156,11 +166,6 @@ def run_policy_engine(database_path: str, show_prelude: bool, policy_file: str) 
     dict
         The policy engine result.
     """
-    if show_prelude:
-        prelude = get_generated(database_path)
-        logger.info("\n%s", prelude)
-        return {}
-
     # TODO: uncomment the following line when the check is improved.
     # _check_version(database_path)
 


### PR DESCRIPTION
**Description**
I fixed issue #250 by assigning both `--file` and `--show-prelude` flags in the `verify-policy` action command to a mutual exclusive group.
This will effective only allow the user to use either `--file` or `--show-prelude` at one time.
I also refactored the code to generate the prelude from a database to a different method rather than putting it inside the same method used for running the policy engine against the policy file provided in `--file`.